### PR TITLE
Add support to store parameter and return info in fiddb.json

### DIFF
--- a/ghidra_scripts/FunctionIdHashFunction.py
+++ b/ghidra_scripts/FunctionIdHashFunction.py
@@ -94,17 +94,13 @@ def generate_function_id_hash(db):
         for p in fn.getParameters():
             arguments.append({
                 "name": p.getName(),
-                "type": p.getDataType().getName(),
-                "storage": serialize_varnodes(p.getVariableStorage().getVarnodes())
+                "type": p.getDataType().getName()
             })
         db.update_database([{
             "0x" + function_id: {
                 "name": fn.getName(),
                 "arguments": arguments,
-                "return": {
-                    "type": fn.getReturn().getDataType().getName(),
-                    "storage": serialize_varnodes(fn.getReturn().getVariableStorage().getVarnodes())
-                }
+                "return": fn.getReturn().getDataType().getName()
             }
         }])
 

--- a/ghidra_scripts/FunctionIdMatcher.py
+++ b/ghidra_scripts/FunctionIdMatcher.py
@@ -35,28 +35,91 @@ def generate_function_ids():
             yield (function.getName(), function.getEntryPoint(), "0x" + function_id)
 
 
+def get_best_matching_datatype(datatype, name, dataTypeManager):
+    candidates = []
+    datatype = dataTypeManager.findDataTypes(name, candidates)
+    if len(candidates) == 1:
+        datatype = candidates[0]
+    return datatype
+
+
+def deserialize_arguments(parameters, arguments, program):
+    dataTypeManager = program.getDataTypeManager()
+    for idx, argument in enumerate(arguments):
+        # TODO: handle if not all parameters were detected (i.e. the parameter code
+        # of "parameters" is smaller than the length of "arguments")
+        newDataType = get_best_matching_datatype(
+            parameters[idx].getDataType(),
+            argument["type"], dataTypeManager
+        )
+
+        newAdress = parameters[idx].getVariableStorage().getVarnodes()[0].getAddress()
+
+        parameters[idx] = ghidra.program.model.listing.ParameterImpl(
+            argument["name"], newDataType, newAdress, program)
+    return parameters
+
+
 def matching_function(config):
     # type (dict) -> None
     functions_ids_db = config["database"]["functions"]
+
+    program = getState().getCurrentProgram()
+    dataTypeManager = program.getDataTypeManager()
+
     for function_name, function_entrypoint, function_id in generate_function_ids():
         if function_id in list(functions_ids_db):
 
             current_function = fm.getFunctionContaining(function_entrypoint)
-            if function_name != functions_ids_db[function_id]:
+            if function_name != functions_ids_db[function_id]["name"]:
+
                 current_function.setName(
-                    functions_ids_db[function_id],
+                    functions_ids_db[function_id]["name"],
                     ghidra.program.model.symbol.SourceType.USER_DEFINED,
                 )
 
-            print(
-                "FunctionEntryPoint: %s\tFunctionID: %s\tOriginalFunctionName: %s\tNewFunctionName: %s"
-                % (
-                    function_entrypoint,
-                    function_id,
-                    function_name,
-                    functions_ids_db[function_id],
+                arguments = deserialize_arguments(
+                    current_function.getParameters(),
+                    functions_ids_db[function_id]["arguments"],
+                    program
                 )
-            )
+
+                current_function.replaceParameters(
+                    ghidra.program.model.listing.Function.FunctionUpdateType.DYNAMIC_STORAGE_FORMAL_PARAMS,
+                    0,
+                    ghidra.program.model.symbol.SourceType.ANALYSIS,
+                    arguments
+                )
+
+                newReturnDatatype = get_best_matching_datatype(
+                    current_function.getReturn().getDataType(),
+                    functions_ids_db[function_id]["return"]["type"],
+                    dataTypeManager
+                )
+                current_function.setReturn(
+                    newReturnDatatype,
+                    current_function.getReturn().getVariableStorage(),
+                    ghidra.program.model.symbol.SourceType.ANALYSIS
+                )
+
+                print(
+                    "FunctionEntryPoint: %s\tFunctionID: %s\tOriginalFunctionName: %s\tNewFunctionName: %s"
+                    % (
+                        function_entrypoint,
+                        function_id,
+                        function_name,
+                        functions_ids_db[function_id]["name"],
+                    )
+                )
+            else:
+                print(
+                    "FunctionEntryPoint: %s\tFunctionID: %s\tKeptFunctionName: %s"
+                    % (
+                        function_entrypoint,
+                        function_id,
+                        function_name,
+                    )
+                )
 
 
 def _load_function_ids_database(config_path):


### PR DESCRIPTION
While function names are really neat, I quickly hit the point where I needed parameter and return type information as well. This replaces the stored values from being only the function name to be a more complex representation.

Please note that I did not keep backwards compatibility with the existing fiddb.json format as I didn't use it beforehand. This could be added if needed, but would complicate the code a bit more.